### PR TITLE
Fixes #47 Add support for numeric values passed to ‘border-spacing’, …

### DIFF
--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -10,6 +10,9 @@ var parse = function parse(v) {
     if (v === '' || v === null) {
         return undefined;
     }
+    if (typeof v === 'number') {
+        v = String(v)
+    }
     if (v.toLowerCase() === 'inherit') {
         return v;
     }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -401,5 +401,12 @@ module.exports = {
         style.background = null;
         test.equal(style.cssText, '', 'cssText is not empty');
         test.done();
+    },
+    'Support non string entries in border-spacing': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(1);
+        style.borderSpacing = 0;
+        test.equal(style.cssText, 'border-spacing: 0;', 'border-spacing is not 0');
+        test.done();
     }
 };


### PR DESCRIPTION
…e.g. ‘border-spacing: 0’. Include test.